### PR TITLE
Simplify the label_for_attribute in favour of modifying FormBlueprint

### DIFF
--- a/src/helpers/form_helpers.php
+++ b/src/helpers/form_helpers.php
@@ -56,14 +56,11 @@ function form_label(array $fieldData)
     return view('forms::label', $fieldData)->render();
 }
 
-function label_for_attribute(array $options)
+function label_for_attribute($options)
 {
-    if(empty($options)) { return ""; }
-    if(empty($options['attr'])) { return ""; }
-    if(!empty($options['attr']['id'])) { // If there is an id, use that
-        return "for='".$options['attr']['id']."'";
-    } elseif (!empty($options['attr']['name'])) { // Otherwise try the name
-        return "for='".$options['attr']['name']."'";
+    if(!empty($options) && !empty($options['attr'])) { 
+        $id = $options['attr']['id'];
+        return "for='".$id."'";
     }
     return "";
 }

--- a/src/helpers/form_helpers.php
+++ b/src/helpers/form_helpers.php
@@ -58,7 +58,7 @@ function form_label(array $fieldData)
 
 function label_for_attribute($options)
 {
-    if(!empty($options) && !empty($options['attr'])) { 
+    if(!empty($options) && !empty($options['attr']) && !empty($options['attr']['id'])) { 
         $id = $options['attr']['id'];
         return "for='".$id."'";
     }


### PR DESCRIPTION
The label for attribute doesn't really work unless their is an id on the target element, so don't bother with the other logic.
